### PR TITLE
Add homepage telemetry placeholders and update handoff

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,3 +6,4 @@ Record notable updates to either site, infrastructure, or planning artifacts.
 |------------|--------|-------|
 | 2025-02-14 | Restructured docs hierarchy and staged future hobby outlines. | Created `docs/` tree, moved planning files, prepared for dual-site setup. |
 | 2025-10-06 | Connected `28eme.ca` consulting site and prepped personal domain migration. | Finalized consulting DNS + forwarding and outlined steps to move `austinbjohnson.com` onto this repo. |
+| 2025-10-07 | Verified TLS for `austinbjohnson.com` custom domain. | Root domain now serves over HTTPS; `www` alias resolves but returns Squarespace 404 while content swaps finalize. |

--- a/handoff.md
+++ b/handoff.md
@@ -1,0 +1,12 @@
+# Handoff Reference
+
+This repo follows the shared workflow documented at the websites root.
+
+- Master session notes: `../handoff/SESSION_NOTES.md`
+- Co-dev reminders: `../REMINDER.md`
+
+## Site-Specific Notes
+
+- [ ] Confirm `www.austinbjohnson.com` serves the GitHub Pages build over HTTPS and update docs once the alias resolves. (2025-10-07 04:11 UTC: still serves Squarespace 404.)
+- [ ] Investigate the Firefox redirect loop (likely leftover Squarespace redirect vs. apex records) and document the fix. Initial check shows apex `austinbjohnson.com` 301s to `https://www.austinbjohnson.com/`, which is still pointed at Squarespace.
+- [x] Simplify the homepage content footprint (contact CTA removed; Strava/Goodreads placeholders added along with Now/reading/automation module roadmap).

--- a/index.html
+++ b/index.html
@@ -171,6 +171,31 @@
       align-items: start;
       margin-top: 2rem;
     }
+    .resource-grid {
+      display: grid;
+      gap: 1.5rem;
+      grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+    }
+    .resource-card {
+      position: relative;
+    }
+    .resource-card a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45rem;
+      margin-top: 1rem;
+      font-weight: 600;
+      text-decoration: none;
+      color: var(--accent);
+    }
+    .resource-card a::after {
+      content: "→";
+      font-size: 0.95rem;
+      transition: transform 160ms ease;
+    }
+    .resource-card a:hover::after {
+      transform: translateX(3px);
+    }
     .github-heatmap img {
       width: 100%;
       border-radius: 1rem;
@@ -299,13 +324,30 @@
       </section>
 
       <section>
-        <h2>Ready to collaborate</h2>
-        <div class="card">
-          <p>Have an AI-native automation idea, a workflow that needs love, or a creative side project you want to amplify? Browse services at <a href="https://28eme.ca" target="_blank" rel="noopener">28eme.ca</a> or reach out directly.</p>
-          <div class="cta-group" style="margin-top:1.8rem;">
-            <a class="cta" href="mailto:hello@28eme.com?subject=Collaboration%20with%2028eme">Start a conversation</a>
-            <a class="cta secondary" href="https://github.com/austinbjohnson" target="_blank" rel="noopener">Latest code & notes</a>
+        <h2>Telemetry placeholders</h2>
+        <p class="section-lead">Activity feeds are coming soon—these cards will light up once automation hooks are wired.</p>
+        <div class="resource-grid">
+          <div class="card resource-card">
+            <h3 style="margin-top:0;">Strava rides & runs</h3>
+            <p>Drafting the connector that pulls ride notes and training blocks directly from Strava without leaking private workouts.</p>
+            <a href="https://www.strava.com/athletes/19650448" target="_blank" rel="noopener">Visit Strava placeholder</a>
           </div>
+          <div class="card resource-card">
+            <h3 style="margin-top:0;">Goodreads reading log</h3>
+            <p>Porting highlights into a lightweight shelf so current reads and automation experiments stay in sync.</p>
+            <a href="https://www.goodreads.com/abj0028" target="_blank" rel="noopener">View Goodreads placeholder</a>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2>Next modules in queue</h2>
+        <div class="card note" style="border-style: solid;">
+          <ul class="todo-list" style="margin:0;">
+            <li><strong>Now blurb:</strong> lightweight snapshot of focus areas, updated monthly.</li>
+            <li><strong>Reading list:</strong> pull Goodreads shelves into themed stacks with automation summaries.</li>
+            <li><strong>Automation lab notes:</strong> short write-ups on experiments before they become full projects.</li>
+          </ul>
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- remove the legacy contact CTA and replace it with telemetry placeholder cards that link to Strava and Goodreads profiles
- add a roadmap section for upcoming Now/reading/automation modules and the supporting layout styles
- log the TLS verification status in the changelog and capture outstanding domain follow-ups in the repo handoff

## Testing
- n/a
